### PR TITLE
[new] support 6000.3.x

### DIFF
--- a/Editor/ObfuscatorBuilder.cs
+++ b/Editor/ObfuscatorBuilder.cs
@@ -90,23 +90,28 @@ namespace Obfuz
 
         public static List<string> BuildUnityAssemblySearchPaths(bool searchPathIncludeUnityEditorDll = false)
         {
+#if UNITY_6000_3_OR_NEWER && UNITY_EDITOR_OSX
+            string monoBleedingEdgePath = "Resources/Scripting/MonoBleedingEdge";
+#else
+            string monoBleedingEdgePath = "MonoBleedingEdge";
+#endif
             string applicationContentsPath = EditorApplication.applicationContentsPath;
             var searchPaths = new List<string>
                 {
 #if UNITY_2021_1_OR_NEWER
-#if UNITY_STANDALONE_WIN || (UNITY_EDITOR_WIN && UNITY_SERVER) || UNITY_WSA || UNITY_LUMIN
-                "MonoBleedingEdge/lib/mono/unityaot-win32",
-                "MonoBleedingEdge/lib/mono/unityaot-win32/Facades",
-#elif UNITY_STANDALONE_OSX || (UNITY_EDITOR_OSX && UNITY_SERVER) || UNITY_IOS || UNITY_TVOS
-                "MonoBleedingEdge/lib/mono/unityaot-macos",
-                "MonoBleedingEdge/lib/mono/unityaot-macos/Facades",
+    #if UNITY_STANDALONE_WIN || (UNITY_EDITOR_WIN && UNITY_SERVER) || UNITY_WSA || UNITY_LUMIN
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-win32",
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-win32/Facades",
+    #elif UNITY_STANDALONE_OSX || (UNITY_EDITOR_OSX && UNITY_SERVER) || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-macos",
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-macos/Facades",
+    #else
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-linux",
+                $"{monoBleedingEdgePath}/lib/mono/unityaot-linux/Facades",
+    #endif
 #else
-                "MonoBleedingEdge/lib/mono/unityaot-linux",
-                "MonoBleedingEdge/lib/mono/unityaot-linux/Facades",
-#endif
-#else
-                "MonoBleedingEdge/lib/mono/unityaot",
-                "MonoBleedingEdge/lib/mono/unityaot/Facades",
+                $"{monoBleedingEdgePath}/lib/mono/unityaot",
+                $"{monoBleedingEdgePath}/lib/mono/unityaot/Facades",
 #endif
 
 #if UNITY_STANDALONE_WIN || (UNITY_EDITOR_WIN && UNITY_SERVER)

--- a/Editor/Utils/PlatformUtil.cs
+++ b/Editor/Utils/PlatformUtil.cs
@@ -26,8 +26,13 @@ namespace Obfuz.Utils
     {
         public static bool IsMonoBackend()
         {
-            return PlayerSettings.GetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup)
-                == ScriptingImplementation.Mono2x;
+            BuildTargetGroup buildTargetGroup = EditorUserBuildSettings.selectedBuildTargetGroup;
+#if UNITY_6000_0_OR_NEWER
+            var namedBuildTarget = UnityEditor.Build.NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+            return PlayerSettings.GetScriptingBackend(namedBuildTarget) == ScriptingImplementation.Mono2x;
+#else
+            return PlayerSettings.GetScriptingBackend(buildTargetGroup) == ScriptingImplementation.Mono2x;
+#endif
         }
     }
 }


### PR DESCRIPTION
1.add support for 6000.3.x;
2.fix deprecated warning of PlayerSettings.GetScriptingBackend(BuildTargetGroup) in Unity 6000